### PR TITLE
chore: trigger ci for all branches except main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: ['push', 'pull_request']
+on:
+  push:
+    branches:
+      - "*"
+      - "!main"
+  pull_request:
 
 jobs:
   tests:


### PR DESCRIPTION
This is to prevent redundant testing as PRs are already being required to be up-to-date