### PR TITLE
chore: add paths in ci workflow and adds ci-skip workflow

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - api/**
+      - client/**
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No tests required
+        run: 'echo "Skipping tests check"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,13 @@ on:
     branches:
       - "*"
       - "!main"
+    paths:
+      - api/**
+      - client/**
   pull_request:
+    paths:
+      - api/**
+      - client/**
 
 jobs:
   tests:


### PR DESCRIPTION
Performs tests only for changes under the `client/` and `api/` directories, adds a new workflow for passing the `tests` check in pull requests that do not involve the same directories.