### PR TITLE
feat: add forecast data titles

### DIFF
--- a/api/AngularDotnetGHActions.API/Controllers/WeatherForecastController.cs
+++ b/api/AngularDotnetGHActions.API/Controllers/WeatherForecastController.cs
@@ -21,7 +21,7 @@ public class WeatherForecastController : ControllerBase
     [HttpGet(Name = "GetWeatherForecast")]
     public IEnumerable<WeatherForecast> Get()
     {
-        return Enumerable.Range(1, 6).Select(index => new WeatherForecast
+        return Enumerable.Range(1, 4).Select(index => new WeatherForecast
         {
             Date = DateTime.Now.AddDays(index),
             TemperatureC = Random.Shared.Next(-20, 55),

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -189,10 +189,22 @@
     *ngFor="let f of forecast"
     class="forecast"
     data-cy="forecast">
-    <div>{{f.date | date: 'mediumDate'}}</div>
-    <div>{{f.temperatureC}}</div>
-    <div>{{f.temperatureF}}</div>
-    <div>{{f.summary}}</div>
+    <div>
+        <span>Date: </span>
+        {{f.date | date: 'mediumDate'}}
+    </div>
+    <div>
+        <span>C: </span>
+        {{f.temperatureC}}°
+    </div>
+    <div>
+        <span>F:</span>
+        {{f.temperatureF}}°
+    </div>
+    <div>
+        <span>Summary:</span>
+        {{f.summary}}
+    </div>
 </div>
 
 <router-outlet></router-outlet>

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -1,9 +1,12 @@
 .forecast {
-    margin-bottom: 8px;
-    padding: 8px;
-    width: 150px;
+    margin-bottom: 16px;
+    padding: 16px;
+    width: 200px;
     font-size: 20px;
     background: #f0f0f0;
     border-radius: 12px;
     text-align: center;
+    span {
+        font-weight: bold;
+    }
 }


### PR DESCRIPTION
Adds a title for each of the forecast properties, reduces the forecast array length by 2