### PR TITLE
chore(client): add release script

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,12 +7,12 @@
     "lint": "ng lint",
     "test": "ng test --code-coverage",
     "test:headless": "ng test --watch false --browsers ChromeHeadless --progress false --code-coverage",
-    "prebuild": "npm version patch --no-git-tag-version",
     "build:prod": "ng build -c production --output-path dist --progress false",
     "start:build": "angular-http-server --path dist -p 4200 --silent",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "build": "ng build -c deploy --output-path dist --progress false"
+    "build": "ng build -c deploy --output-path dist --progress false",
+    "release": "npm version"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Gets rid of the prebuild script for manually configuring a new release version via the release script